### PR TITLE
Throw exception when TM stream is missing in configuration

### DIFF
--- a/yamcs-core/src/main/java/org/yamcs/StreamTmPacketProvider.java
+++ b/yamcs-core/src/main/java/org/yamcs/StreamTmPacketProvider.java
@@ -66,6 +66,8 @@ public class StreamTmPacketProvider extends AbstractProcessorService implements 
 
         for (String streamName : streams) {
             TmStreamConfigEntry sce = streamConfig.getTmEntry(streamName);
+            if (sce == null) throw new ConfigurationException("Cannot find TM stream configuration for '" + streamName + "'");
+
             SequenceContainer rootContainer;
             rootContainer = sce.getRootContainer();
             if (rootContainer == null) {


### PR DESCRIPTION
If a stream is referenced in `processor.yaml`, but then not defined in `yamcs.sle.yaml`, yamcs panics.

This PR adds a simple check and throw an exception with a proper message.